### PR TITLE
增加功能和位置改进

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 #### 🌱 I’m currently learning Minecraft redstone!
 
- ![VGTB2021's GitHub stats](https://github-readme-stats.vercel.app/api?username=VGTB2021&hide=issues&count_private=true&show_icons=true&include_all_commits=true&hide_border=true&bg_color=30,DCE35B,45B649&title_color=3B4371&icon_color=3B4371&text_color=3B4371)
-
+<div align=center><p> <img alt="VGTB2021&#39;s GitHub stats" src="https://github-readme-stats.vercel.app/api?username=VGTB2021&amp;hide=issues&amp;count_private=true&amp;show_icons=true&amp;include_all_commits=true&amp;hide_border=true&amp;bg_color=30,DCE35B,45B649&amp;title_color=3B4371&amp;icon_color=3B4371&amp;text_color=3B4371"/></p>
 
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=VGTB2021&repo=VGTB2021.github.io&hide_border=true&bg_color=30,DCE35B,45B649&title_color=3B4371&icon_color=3B4371&text_color=3B4371)](https://github.com/VGTB2021/VGTB2021.github.io)
 [![Readme Card](https://github-readme-stats.vercel.app/api/pin/?username=VGTB2021&repo=VGTB2021&hide_border=true&bg_color=30,DCE35B,45B649&title_color=3B4371&icon_color=3B4371&text_color=3B4371)](https://github.com/VGTB2021/VGTB2021)


### PR DESCRIPTION
把点击统计的图片跳转到github个人页面（原先是跳转到一个新标签页打开该图片）

个人统计卡片居中